### PR TITLE
Add webworker rendering to the vite embedded demo example

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { createRoot, hydrateRoot } from 'react-dom/client'
 import '@fontsource/roboto'
 import {
   createViewState,
@@ -21,9 +22,23 @@ function View() {
       assembly,
       tracks,
       defaultSession,
+
       onChange: patch => {
         setPatches(previous => previous + JSON.stringify(patch) + '\n')
       },
+      configuration: {
+        rpc: {
+          defaultDriver: 'WebWorkerRpcDriver',
+        },
+      },
+      makeWorkerInstance: () => {
+        return new Worker(new URL('./rpcWorker', import.meta.url), {
+          type: 'module',
+        })
+      },
+
+      hydrateFn: hydrateRoot,
+      createRootFn: createRoot,
     })
     setViewState(state)
   }, [])

--- a/src/rpcWorker.ts
+++ b/src/rpcWorker.ts
@@ -1,0 +1,20 @@
+import './workerPolyfill'
+import { initializeWorker } from '@jbrowse/product-core'
+import { enableStaticRendering } from 'mobx-react'
+
+// locals
+import corePlugins from '@jbrowse/react-linear-genome-view/esm/corePlugins'
+import { Buffer } from 'buffer'
+
+self.Buffer = Buffer
+
+// static rendering is used for "SSR" style rendering which is done on the
+// worker
+enableStaticRendering(true)
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+initializeWorker(corePlugins, {})
+
+export default function doNothing() {
+  /* do nothing */
+}

--- a/src/workerPolyfill.js
+++ b/src/workerPolyfill.js
@@ -1,0 +1,31 @@
+// this is a little polyfill for running in workers that
+// contains just enough stubbing to make webpack style-loader
+// think that it is actually inserting styles into the DOM
+
+self.window = {
+  addEventListener() {},
+  fetch: self.fetch.bind(self),
+  location: self.location,
+  Date: self.Date,
+  requestIdleCallback: cb => cb(),
+  cancelIdleCallback: () => {},
+  requestAnimationFrame: cb => cb(),
+  cancelAnimationFrame: () => {},
+  navigator: {},
+}
+self.document = {
+  createTextNode() {},
+  querySelector() {
+    return { appendChild() {} }
+  },
+  documentElement: {},
+  querySelectorAll: () => [],
+  createElement() {
+    return {
+      style: {},
+      setAttribute() {},
+      removeAttribute() {},
+      appendChild() {},
+    }
+  },
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: './',
+  worker: {
+    format: 'es',
+  },
 })


### PR DESCRIPTION
Fixes https://github.com/GMOD/jbrowse-components/issues/3730

It is a little tricky because it requires setting {type:'module'} on the new Worker, which the @jbrowse/react-linear-genome-view/esm/makeWorkerInstance does not do. We could add this though

currently, the workers do offer better performance, so it is beneficial to make our embedded examples include this functionality if possible